### PR TITLE
Fix PlatformIO compilation, add CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+    - name: Run PlatformIO
+      run: pio run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run
+      run: pio run -d Platformio

--- a/Platformio/platformio.ini
+++ b/Platformio/platformio.ini
@@ -22,7 +22,7 @@ monitor_speed = 115200
 upload_speed = 921600
 lib_deps =  adafruit/RTClib
             bblanchon/ArduinoJson
-            paulstoffregen/Time@
+            paulstoffregen/Time
             jchristensen/Timezone @ ^1.2.4
             ;knolleary/PubSubClient @ ^2.8
             ;adafruit/Adafruit Unified Sensor @ ^1.1.4

--- a/Platformio/platformio.ini
+++ b/Platformio/platformio.ini
@@ -12,7 +12,7 @@
 data_dir  = ./data
 
 [env:esp32dev]
-platform = espressif32
+platform = espressif32@3.5.0
 board = esp32dev
 ;board_build.filesystem = littlefs
 ;build_flags = -Wl,-Teagle.flash.4m1m.ld 
@@ -20,25 +20,28 @@ board = esp32dev
 framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
-lib_deps =  RTClib
-            ArduinoJson
-            Time
+lib_deps =  adafruit/RTClib
+            bblanchon/ArduinoJson
+            paulstoffregen/Time@
             jchristensen/Timezone @ ^1.2.4
             ;knolleary/PubSubClient @ ^2.8
             ;adafruit/Adafruit Unified Sensor @ ^1.1.4
             ;adafruit/DHT sensor library @ ^1.4.2
-            FastLED
+            fastled/FastLED
             luc-github/ESP32SSDP @ ^1.1.1
             ;lorol/LittleFS_esp32 @ ^1.0.6
             pixelmatix/SmartMatrix @ ^4.0.3
             adafruit/Adafruit GFX Library @ ^1.10.10
-            AsyncTCP
-            ESP Async WebServer
+            me-no-dev/AsyncTCP
+            me-no-dev/ESP Async WebServer
             ;witnessmenow/YoutubeApi @ ^2.0.0
+            https://github.com/Lightwell-bg/ssdpAWS/archive/refs/heads/master.zip
+            https://github.com/Lightwell-bg/NetCrtESP/archive/refs/heads/master.zip
+            https://github.com/Lightwell-bg/ESPTimeFunc/archive/refs/heads/master.zip
+            https://github.com/Lightwell-bg/weatherAp/archive/refs/heads/main.zip
 
 ;extra_scripts = ./littlefsbuilder.py
 # explicitly ignore TinyWireM
 ;lib_ignore =    TinyWireM
 # Resolve hidden dependencies under ifdef
 lib_ldf_mode = deep+ 
-lib_extra_dirs = D:\1APACER\Help\ArduinoProjectsPIO\library

--- a/Platformio/platformio.ini
+++ b/Platformio/platformio.ini
@@ -38,7 +38,9 @@ lib_deps =  adafruit/RTClib
             https://github.com/Lightwell-bg/ssdpAWS/archive/refs/heads/master.zip
             https://github.com/Lightwell-bg/NetCrtESP/archive/refs/heads/master.zip
             https://github.com/Lightwell-bg/ESPTimeFunc/archive/refs/heads/master.zip
-            https://github.com/Lightwell-bg/weatherAp/archive/refs/heads/main.zip
+            ; temporarily until the PR lands for Linux
+            https://github.com/maxgerhardt/weatherAp/archive/refs/heads/main.zip
+            ;https://github.com/Lightwell-bg/weatherAp/archive/refs/heads/main.zip
 
 ;extra_scripts = ./littlefsbuilder.py
 # explicitly ignore TinyWireM

--- a/Platformio/src/config.h
+++ b/Platformio/src/config.h
@@ -33,7 +33,7 @@ const String nVersion = "v2.0";
 #include <Timezone.h>           //https://github.com/JChristensen/Timezone
 #include "NetCrtESP.h"
 #include "ESPTimeFunc.h"
-#include "weatherAP.h"
+#include "weatherAp.h"
 #include "newsAp.h"
 #define USE_ADAFRUIT_GFX_LAYERS
 #include <MatrixHardware_ESP32_V0.h>                // This file contains multiple ESP32 hardware configurations, edit the file to define GPIOPINOUT (or add #define GPIOPINOUT with a hardcoded number before this #include)


### PR DESCRIPTION
* make project use correct 1.0.6 Arduino-ESP32 core (does not compile with 2.x due to changed macro names for register access)
* add author names in libraries
* transform libraries referenced by local path `lib_extra_dirs = D:\1APACER\Help\ArduinoProjectsPIO\library` into the actual repos
* fix header name for case-sensitive file systems (`weatherAp.h`)
* use Github Actions to test-compile the firmware
* needs https://github.com/Lightwell-bg/weatherAp/pull/1 to be merged so that the lightwell-bg repo can be used

Fixes #1 