### PR TITLE
Switch back to Lightwell-bg's weatherAp version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: PlatformIO CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/Platformio/platformio.ini
+++ b/Platformio/platformio.ini
@@ -38,9 +38,7 @@ lib_deps =  adafruit/RTClib
             https://github.com/Lightwell-bg/ssdpAWS/archive/refs/heads/master.zip
             https://github.com/Lightwell-bg/NetCrtESP/archive/refs/heads/master.zip
             https://github.com/Lightwell-bg/ESPTimeFunc/archive/refs/heads/master.zip
-            ; temporarily until the PR lands for Linux
-            https://github.com/maxgerhardt/weatherAp/archive/refs/heads/main.zip
-            ;https://github.com/Lightwell-bg/weatherAp/archive/refs/heads/main.zip
+            https://github.com/Lightwell-bg/weatherAp/archive/refs/heads/main.zip
 
 ;extra_scripts = ./littlefsbuilder.py
 # explicitly ignore TinyWireM


### PR DESCRIPTION
Since https://github.com/Lightwell-bg/weatherAp/pull/1 was merged, this doesn't need to use my fork anymore.